### PR TITLE
fix: add value param to dynamic modal decorator

### DIFF
--- a/content/interactions/modals.md
+++ b/content/interactions/modals.md
@@ -52,8 +52,8 @@ import { Context, Modal, ModalContext,ModalParam } from 'necord';
 
 @Injectable()
 export class DiscordService {
-    @Modal('pizza')
-    public onModal(@Ctx() [interaction]: ModalContext,@ModalParam('value') value: string) {
+    @Modal('pizza/:value')
+    public onModal(@Ctx() [interaction]: ModalContext, @ModalParam('value') value: string) {
       return interaction.reply({
         content: `Your fav pizza ${value} : ${interaction.fields.getTextInputValue('pizza')}`
       });


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

It was missing the `/:value` to Dynamic Modal example
