### PR TITLE
docs: Rename event from 'ready' to 'clientReady'

### DIFF
--- a/content/intro.mdx
+++ b/content/intro.mdx
@@ -93,8 +93,8 @@ export class AppUpdate {
 
     public constructor(private readonly client: Client) {}
 
-    @Once('ready')
-    public onReady(@Context() [client]: ContextOf<'ready'>) {
+    @Once('clientReady')
+    public onReady(@Context() [client]: ContextOf<'clientReady'>) {
         this.logger.log(`Bot logged in as ${client.user.username}`);
     }
 

--- a/content/listeners.mdx
+++ b/content/listeners.mdx
@@ -23,8 +23,8 @@ import { Once, On, Context, ContextOf } from 'necord';
 export class AppService {
     private readonly logger = new Logger(AppService.name);
 
-    @Once('ready')
-    public onReady(@Context() [client]: ContextOf<'ready'>) {
+    @Once('clientReady')
+    public onReady(@Context() [client]: ContextOf<'clientReady'>) {
         this.logger.log(`Bot logged in as ${client.user.username}`);
     }
 


### PR DESCRIPTION
As ready is now deprecated: https://discord.js.org/docs/packages/discord.js/14.22.1/Client:Class#ready, change the documentation to match this

**Please describe the changes this PR makes and why it should be merged:**

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
